### PR TITLE
Add vibration graph to measurement tasks

### DIFF
--- a/src/views/aiot/measurementTasks/components/VibrationGraph.vue
+++ b/src/views/aiot/measurementTasks/components/VibrationGraph.vue
@@ -1,0 +1,73 @@
+<template>
+  <div>
+    <el-radio-group v-model="graphType" class="mb-10px">
+      <el-radio-button label="RMS">RMS</el-radio-button>
+      <el-radio-button label="RMSMA">RMSMA</el-radio-button>
+      <el-radio-button label="PeakToPeak">PeakToPeak</el-radio-button>
+    </el-radio-group>
+    <Echart :height="350" :options="chartOptions" v-loading="loading" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { EChartsOption } from 'echarts'
+import { watch, reactive, ref } from 'vue'
+import { formatDate } from '@/utils/formatTime'
+import { MeasurementTasksApi } from '@/api/aiot/measurementTasks'
+
+/** 振动图表 */
+defineOptions({ name: 'VibrationGraph' })
+
+const props = defineProps<{ taskId?: number }>()
+
+const graphType = ref<'RMS' | 'RMSMA' | 'PeakToPeak'>('RMS')
+const loading = ref(false)
+const chartOptions = reactive<EChartsOption>({
+  grid: { left: 50, right: 20, bottom: 20, top: 60, containLabel: true },
+  legend: { data: ['X轴', 'Y轴', 'Z轴'], top: 20 },
+  tooltip: {
+    trigger: 'axis',
+    axisPointer: { type: 'cross' },
+    padding: [5, 10]
+  },
+  xAxis: { type: 'category', data: [], boundaryGap: false, axisTick: { show: false } },
+  yAxis: { axisTick: { show: false } },
+  series: [
+    { name: 'X轴', type: 'line', smooth: true, data: [] },
+    { name: 'Y轴', type: 'line', smooth: true, data: [] },
+    { name: 'Z轴', type: 'line', smooth: true, data: [] }
+  ]
+})
+
+const loadData = async () => {
+  if (!props.taskId) {
+    chartOptions.xAxis!['data'] = []
+    chartOptions.series?.forEach((s) => (s.data = []))
+    return
+  }
+  loading.value = true
+  try {
+    const data = await MeasurementTasksApi.getVibrationRecordsPage({
+      pageNo: 1,
+      pageSize: 1000,
+      taskId: props.taskId
+    })
+    const list = data.list || []
+    chartOptions.xAxis!['data'] = list.map((item: any) => formatDate(item.timestamp, 'MM-DD HH:mm'))
+    const map = {
+      RMS: ['xAxisRms', 'yAxisRms', 'zAxisRms'],
+      RMSMA: ['xAxisMaRms', 'yAxisMaRms', 'zAxisMaRms'],
+      PeakToPeak: ['xAxisPeakToPeak', 'yAxisPeakToPeak', 'zAxisPeakToPeak']
+    }
+    const keys = map[graphType.value]
+    chartOptions.series?.forEach((s, index) => {
+      // @ts-ignore
+      s.data = list.map((item: any) => item[keys[index]])
+    })
+  } finally {
+    loading.value = false
+  }
+}
+
+watch([() => props.taskId, graphType], loadData, { immediate: true })
+</script>

--- a/src/views/aiot/measurementTasks/index.vue
+++ b/src/views/aiot/measurementTasks/index.vue
@@ -212,9 +212,12 @@
   <MeasurementTasksForm ref="formRef" @success="getList" />
   <!-- 子表的列表 -->
   <ContentWrap>
-    <el-tabs model-value="vibrationRecords">
+    <el-tabs v-model="activeTab">
       <el-tab-pane label="振动传感记录" name="vibrationRecords">
         <VibrationRecordsList :task-id="currentRow.id" />
+      </el-tab-pane>
+      <el-tab-pane label="振动图表" name="vibrationGraph">
+        <VibrationGraph :task-id="currentRow.id" />
       </el-tab-pane>
     </el-tabs>
   </ContentWrap>
@@ -227,6 +230,7 @@ import download from '@/utils/download'
 import { MeasurementTasksApi, MeasurementTasksVO } from '@/api/aiot/measurementTasks'
 import MeasurementTasksForm from './MeasurementTasksForm.vue'
 import VibrationRecordsList from './components/VibrationRecordsList.vue'
+import VibrationGraph from './components/VibrationGraph.vue'
 
 /** 检测任务记录 列表 */
 defineOptions({ name: 'MeasurementTasks' })
@@ -252,6 +256,7 @@ const queryParams = reactive({
 })
 const queryFormRef = ref() // 搜索的表单
 const exportLoading = ref(false) // 导出的加载中
+const activeTab = ref('vibrationRecords')
 
 /** 查询列表 */
 const getList = async () => {


### PR DESCRIPTION
## Summary
- add `VibrationGraph` component showing RMS/RMSMA/PeakToPeak charts
- display the new graph in measurement tasks tabs

## Testing
- `npx prettier -w src/views/aiot/measurementTasks/index.vue src/views/aiot/measurementTasks/components/VibrationGraph.vue`
- `pnpm lint:eslint` *(fails: ESLint couldn't find a config)*
- `pnpm lint:style` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853df8e83b08329aa693086e158b102