### PR TITLE
Add CSV import for vibration records

### DIFF
--- a/src/api/aiot/measurementTasks/index.ts
+++ b/src/api/aiot/measurementTasks/index.ts
@@ -56,6 +56,11 @@ export const MeasurementTasksApi = {
     return await request.post({ url: `/aiot/measurement-tasks/vibration-records/create`, data })
   },
 
+  // 批量新增振动传感记录
+  batchCreateVibrationRecords: async (data) => {
+    return await request.post({ url: `/aiot/measurement-tasks/vibration-records/batch-create`, data })
+  },
+
   // 修改振动传感记录
   updateVibrationRecords: async (data) => {
     return await request.put({ url: `/aiot/measurement-tasks/vibration-records/update`, data })

--- a/src/views/aiot/measurementTasks/components/VibrationRecordsForm.vue
+++ b/src/views/aiot/measurementTasks/components/VibrationRecordsForm.vue
@@ -73,14 +73,20 @@ const formRef = ref() // 表单 Ref
 
 /** 打开弹窗
  * @param type   - create 或 update
- * @param taskId - 父级任务 ID，必填
- * @param id     - 如果是 update，就传要编辑的记录 ID；create 时不传
+ * @param taskId   - 父级任务 ID，必填
+ * @param sensorId - 传感器 ID，必填
+ * @param id       - 如果是 update，就传要编辑的记录 ID；create 时不传
  */
-const open = async (type: 'create' | 'update', taskId: number, id?: number) => {
+const open = async (
+  type: 'create' | 'update',
+  taskId: number,
+  sensorId: number,
+  id?: number
+) => {
   dialogVisible.value = true
   dialogTitle.value = t('action.' + type)
   formType.value = type
-  resetForm(taskId)
+  resetForm(taskId, sensorId)
   // 修改时，设置数据
   if (id) {
     formLoading.value = true
@@ -119,10 +125,10 @@ const submitForm = async () => {
 }
 
 /** 重置表单 */
-const resetForm = (keepTaskId?: number) => {
+const resetForm = (keepTaskId?: number, keepSensorId?: number) => {
   Object.assign(formData, {
     id: undefined,
-    sensorId: undefined,
+    sensorId: keepSensorId ?? undefined,
     taskId: keepTaskId ?? undefined,
     timestamp: undefined,
     xAxisRms: undefined,

--- a/src/views/aiot/measurementTasks/components/VibrationRecordsImportForm.vue
+++ b/src/views/aiot/measurementTasks/components/VibrationRecordsImportForm.vue
@@ -1,0 +1,91 @@
+<template>
+  <Dialog v-model="dialogVisible" title="振动记录导入" width="400">
+    <el-upload
+      ref="uploadRef"
+      v-model:file-list="fileList"
+      :auto-upload="false"
+      :limit="1"
+      :disabled="formLoading"
+      accept=".csv"
+      drag
+    >
+      <Icon icon="ep:upload" />
+      <div class="el-upload__text">将文件拖到此处，或<em>点击上传</em></div>
+    </el-upload>
+    <template #footer>
+      <el-button type="primary" :disabled="formLoading" @click="submitForm">确定</el-button>
+      <el-button @click="dialogVisible = false">取消</el-button>
+    </template>
+  </Dialog>
+</template>
+<script setup lang="ts">
+import { MeasurementTasksApi } from '@/api/aiot/measurementTasks'
+import type { VibrationRecordsVO } from '@/api/aiot/vibrationRecords'
+
+const message = useMessage()
+const props = defineProps<{
+  taskId: number
+  sensorId: number
+}>()
+const emits = defineEmits(['success'])
+
+const dialogVisible = ref(false)
+const formLoading = ref(false)
+const fileList = ref<any[]>([])
+const uploadRef = ref()
+
+const open = () => {
+  dialogVisible.value = true
+  fileList.value = []
+}
+
+defineExpose({ open })
+
+const parseCsv = async (file: File) => {
+  const text = await file.text()
+  const lines = text.split(/\r?\n/).filter((line) => line.trim())
+  const headers = lines.shift()?.split(/,\s*/) || []
+  return lines.map((line) => {
+    const cols = line.split(/,\s*/)
+    const obj: Record<string, string> = {}
+    headers.forEach((h, idx) => {
+      obj[h.trim()] = cols[idx]?.trim()
+    })
+    return obj
+  })
+}
+
+const submitForm = async () => {
+  if (fileList.value.length === 0) {
+    message.error('请上传文件')
+    return
+  }
+  const file = fileList.value[0].raw as File
+  formLoading.value = true
+  try {
+    const rows = await parseCsv(file)
+    const list: VibrationRecordsVO[] = rows.map((row) => ({
+      taskId: props.taskId,
+      sensorId: props.sensorId,
+      timestamp: new Date(Number(row.Timestamp) || Date.parse(row.Timestamp)),
+      xAxisRms: Number(row.X_Axis_RMS),
+      yAxisRms: Number(row.Y_Axis_RMS),
+      zAxisRms: Number(row.Z_Axis_RMS),
+      xAxisMaRms: Number(row.X_Axis_MovingAvgRMS),
+      yAxisMaRms: Number(row.Y_Axis_MovingAvgRMS),
+      zAxisMaRms: Number(row.Z_Axis_MovingAvgRMS),
+      xAxisPeakToPeak: Number(row.X_Axis_PeaktoPeak),
+      yAxisPeakToPeak: Number(row.Y_Axis_PeaktoPeak),
+      zAxisPeakToPeak: Number(row.Z_Axis_PeaktoPeak)
+    }))
+    await MeasurementTasksApi.batchCreateVibrationRecords({ list })
+    message.success('导入成功')
+    dialogVisible.value = false
+    emits('success')
+  } catch (e) {
+    message.error('导入失败')
+  } finally {
+    formLoading.value = false
+  }
+}
+</script>

--- a/src/views/aiot/measurementTasks/components/VibrationRecordsList.vue
+++ b/src/views/aiot/measurementTasks/components/VibrationRecordsList.vue
@@ -9,6 +9,15 @@
     >
       <Icon icon="ep:plus" class="mr-5px" /> 新增
     </el-button>
+    <el-button
+      v-if="total === 0"
+      type="warning"
+      plain
+      @click="handleImport"
+      v-hasPermi="['aiot:measurement-tasks:create']"
+    >
+      <Icon icon="ep:upload" class="mr-5px" /> 导入
+    </el-button>
     <el-table v-loading="loading" :data="list" :stripe="true" :show-overflow-tooltip="true">
       <el-table-column label="传感器ID" align="center" prop="sensorId" />
 
@@ -59,17 +68,26 @@
   </ContentWrap>
   <!-- 表单弹窗：添加/修改 -->
   <VibrationRecordsForm ref="formRef" @success="getList" />
+  <!-- 导入弹窗 -->
+  <VibrationRecordsImportForm
+    :task-id="props.taskId!"
+    :sensor-id="props.sensorId!"
+    ref="importRef"
+    @success="getList"
+  />
 </template>
 <script setup lang="ts">
 import { dateFormatter } from '@/utils/formatTime'
 import { MeasurementTasksApi } from '@/api/aiot/measurementTasks'
 import VibrationRecordsForm from './VibrationRecordsForm.vue'
+import VibrationRecordsImportForm from './VibrationRecordsImportForm.vue'
 
 const { t } = useI18n() // 国际化
 const message = useMessage() // 消息弹窗
 
 const props = defineProps<{
   taskId?: number // 任务ID（主表的关联字段）
+  sensorId?: number // 传感器ID（主表字段）
 }>()
 const loading = ref(false) // 列表的加载中
 const list = ref([]) // 列表的数据
@@ -113,12 +131,22 @@ const handleQuery = () => {
 
 /** 添加/修改操作 */
 const formRef = ref()
+const importRef = ref()
 const openForm = (type: string, id?: number) => {
-  if (!props.taskId) {
+  if (!props.taskId || !props.sensorId) {
     message.error('请选择一个检测任务记录')
     return
   }
-  formRef.value.open(type, props.taskId, id)
+  formRef.value.open(type, props.taskId, props.sensorId, id)
+}
+
+/** 导入按钮操作 */
+const handleImport = () => {
+  if (!props.taskId || !props.sensorId) {
+    message.error('请选择一个检测任务记录')
+    return
+  }
+  importRef.value.open()
 }
 
 /** 删除按钮操作 */

--- a/src/views/aiot/measurementTasks/index.vue
+++ b/src/views/aiot/measurementTasks/index.vue
@@ -214,7 +214,10 @@
   <ContentWrap>
     <el-tabs v-model="activeTab">
       <el-tab-pane label="振动传感记录" name="vibrationRecords">
-        <VibrationRecordsList :task-id="currentRow.id" />
+        <VibrationRecordsList
+          :task-id="currentRow.id"
+          :sensor-id="currentRow.sensorId"
+        />
       </el-tab-pane>
       <el-tab-pane label="振动图表" name="vibrationGraph">
         <VibrationGraph :task-id="currentRow.id" />


### PR DESCRIPTION
## Summary
- support batch create vibration records via CSV
- expose `batchCreateVibrationRecords` API
- add import dialog and button when no records exist
- ensure sensorId and taskId are included for CSV import
- pass sensorId to record forms

## Testing
- `pnpm lint:eslint` *(fails: ESLint couldn't find configuration)*
- `pnpm ts:check` *(fails: vue-tsc not found)*
- `pnpm lint:style` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ef3902088329b0fbc52366c8496c