### PR TITLE
Fix measurement task form

### DIFF
--- a/src/views/aiot/measurementTasks/MeasurementTasksForm.vue
+++ b/src/views/aiot/measurementTasks/MeasurementTasksForm.vue
@@ -37,7 +37,7 @@
           </el-radio>
         </el-radio-group>
       </el-form-item>
-      <el-form-item label="开始时间" prop="startTime">
+      <el-form-item v-if="formType !== 'create'" label="开始时间" prop="startTime">
         <el-date-picker
           v-model="formData.startTime"
           type="date"
@@ -45,7 +45,7 @@
           placeholder="选择开始时间"
         />
       </el-form-item>
-      <el-form-item label="结束时间" prop="endTime">
+      <el-form-item v-if="formType !== 'create'" label="结束时间" prop="endTime">
         <el-date-picker
           v-model="formData.endTime"
           type="date"
@@ -100,8 +100,8 @@ const formRules = reactive({
   machineLocationId: [{ required: true, message: '设备位置id不能为空', trigger: 'blur' }],
   type: [{ required: true, message: '检测类型不能为空', trigger: 'change' }],
   method: [{ required: true, message: '检测方法不能为空', trigger: 'change' }],
-  startTime: [{ required: true, message: '开始时间不能为空', trigger: 'blur' }],
-  endTime: [{ required: true, message: '结束时间不能为空', trigger: 'blur' }]
+  startTime: [] as any[],
+  endTime: [] as any[]
 })
 const formRef = ref() // 表单 Ref
 
@@ -111,6 +111,13 @@ const open = async (type: string, id?: number) => {
   dialogTitle.value = t('action.' + type)
   formType.value = type
   resetForm()
+  if (type === 'create') {
+    formRules.startTime = []
+    formRules.endTime = []
+  } else {
+    formRules.startTime = [{ required: true, message: '开始时间不能为空', trigger: 'blur' }]
+    formRules.endTime = [{ required: true, message: '结束时间不能为空', trigger: 'blur' }]
+  }
   // 修改时，设置数据
   if (id) {
     formLoading.value = true

--- a/src/views/aiot/measurementTasks/components/VibrationGraph.vue
+++ b/src/views/aiot/measurementTasks/components/VibrationGraph.vue
@@ -53,7 +53,9 @@ const loadData = async () => {
       taskId: props.taskId
     })
     const list = data.list || []
-    chartOptions.xAxis!['data'] = list.map((item: any) => formatDate(item.timestamp, 'MM-DD HH:mm'))
+    chartOptions.xAxis!['data'] = list.map((item: any) =>
+      formatDate(item.timestamp, 'MM-DD HH:mm:ss')
+    )
     const map = {
       RMS: ['xAxisRms', 'yAxisRms', 'zAxisRms'],
       RMSMA: ['xAxisMaRms', 'yAxisMaRms', 'zAxisMaRms'],

--- a/src/views/aiot/measurementTasks/components/VibrationRecordsForm.vue
+++ b/src/views/aiot/measurementTasks/components/VibrationRecordsForm.vue
@@ -8,12 +8,12 @@
       v-loading="formLoading"
     >
       <el-form-item label="传感器ID" prop="sensorId">
-        <el-input v-model="formData.sensorId" placeholder="请输入传感器ID" />
+        <el-input v-model="formData.sensorId" placeholder="请输入传感器ID"  readonly />
       </el-form-item>
       <el-form-item label="数据采集时间" prop="timestamp">
         <el-date-picker
           v-model="formData.timestamp"
-          type="date"
+          type="datetime" format="YYYY-MM-DD HH:mm:ss.SSS"
           value-format="x"
           placeholder="选择数据采集时间"
         />

--- a/src/views/aiot/measurementTasks/components/VibrationRecordsList.vue
+++ b/src/views/aiot/measurementTasks/components/VibrationRecordsList.vue
@@ -37,7 +37,7 @@
       <el-table-column label="X轴峰值-峰值" align="center" prop="xAxisPeakToPeak" />
       <el-table-column label="Y轴峰值-峰值" align="center" prop="yAxisPeakToPeak" />
       <el-table-column label="Z轴峰值-峰值" align="center" prop="zAxisPeakToPeak" />
-      <el-table-column label="操作" align="center">
+      <el-table-column label="操作" align="center" min-width="120px">
         <template #default="scope">
           <el-button
             link


### PR DESCRIPTION
## Summary
- hide start and end time fields when creating measurement tasks

## Testing
- `pnpm lint:eslint` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm lint:style` *(fails: stylelint not found)*
- `pnpm lint:format`


------
https://chatgpt.com/codex/tasks/task_e_6856769f38248329810e497334ac7bb3